### PR TITLE
Perf: Better Tree Shaking

### DIFF
--- a/components/ObjectInspector/src/ObjectValue.tsx
+++ b/components/ObjectInspector/src/ObjectValue.tsx
@@ -164,15 +164,6 @@ export const ObjectValue = (props: ObjectValueProps) => {
         showKey,
         ast.depth
       );
-    } else if (typeof Buffer !== "undefined" && Buffer.isBuffer(ast.value)) {
-      // Buffer
-      value = buildValue(
-        ast.key,
-        `Buffer[${ast.value.length}]`,
-        styles.value,
-        showKey,
-        ast.depth
-      );
     } else if (isObject(ast.value)) {
       // Object
       value = buildValue(ast.key, "{…}", styles.key, showKey, ast.depth);

--- a/packages/object-parser/package.json
+++ b/packages/object-parser/package.json
@@ -14,6 +14,7 @@
     "registry": "https://registry.npmjs.org/",
     "access": "public"
   },
+  "sideEffects": false,
   "scripts": {
     "clean": "ds clean",
     "build": "ds build",

--- a/packages/port-controller/package.json
+++ b/packages/port-controller/package.json
@@ -13,6 +13,7 @@
     "registry": "https://registry.npmjs.org/",
     "access": "public"
   },
+  "sideEffects": false,
   "license": "MIT",
   "scripts": {
     "clean": "ds clean",

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -35,8 +35,7 @@
   "dependencies": {
     "@babel/runtime": "~7.5.4",
     "@design-systems/utils": "2.12.0",
-    "clsx": "1.1.0",
-    "react-device-detect": "1.15.0"
+    "clsx": "1.1.0"
   },
   "peerDependencies": {
     "react": ">= 16.8.6"

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -14,6 +14,7 @@
     "registry": "https://registry.npmjs.org/",
     "access": "public"
   },
+  "sideEffects": false,
   "scripts": {
     "clean": "ds clean",
     "build": "ds build",

--- a/packages/themes/src/AutoThemeProvider.tsx
+++ b/packages/themes/src/AutoThemeProvider.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { isFirefox } from "react-device-detect";
+import { all } from "./themes";
+import { ThemeableElement, ThemeContext } from "./utils";
+
+export interface AutoThemeProviderProps extends ThemeableElement<"div"> {
+  /** Whether to automatically change the font and background color */
+  autoStyle?: boolean;
+  /** Any React node children */
+  children: React.ReactNode;
+}
+
+/**
+ * Determine if the user has a "prefers-color-scheme" mode enabled in their browser.
+ * This is helpful for detecting if a user prefers dark mode.
+ */
+const useDarkMode = () => {
+  const [darkMode, setDarkMode] = React.useState(
+    window ? window.matchMedia("(prefers-color-scheme: dark)").matches : false
+  );
+
+  React.useEffect(() => {
+    if (!window) {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+
+    /** Run when the user changes this setting. */
+    const changeDarkMode = () => setDarkMode(!darkMode);
+
+    mediaQuery.addListener(changeDarkMode);
+
+    return () => {
+      mediaQuery.removeListener(changeDarkMode);
+    };
+  }, [darkMode]);
+
+  return darkMode;
+};
+
+/**
+ * A theme provider that automatically detects a users browser and colorScheme.
+ * Themes are set for each component using React Context.
+ * It also sets the background color and text color to the correct color.
+ */
+export const AutoThemeProvider = ({
+  theme: propsTheme,
+  colorScheme: propsColorScheme,
+  autoStyle,
+  children,
+  ...html
+}: AutoThemeProviderProps) => {
+  const isDark = useDarkMode();
+  const colorScheme = propsColorScheme || (isDark ? "dark" : "light");
+  const theme = propsTheme || (isFirefox ? "firefox" : "chrome");
+  const style = {
+    backgroundColor: all[theme][colorScheme].backgroundColor,
+    color: all[theme][colorScheme].textColor,
+    minHeight: "100%",
+    width: "100%",
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, colorScheme }}>
+      <div style={autoStyle ? style : undefined} {...html}>
+        {children}
+      </div>
+    </ThemeContext.Provider>
+  );
+};

--- a/packages/themes/src/AutoThemeProvider.tsx
+++ b/packages/themes/src/AutoThemeProvider.tsx
@@ -1,7 +1,11 @@
 import React from "react";
-import { isFirefox } from "react-device-detect";
 import { all } from "./themes";
 import { ThemeableElement, ThemeContext } from "./utils";
+
+let isFirefox = false;
+if (window?.navigator?.userAgent) {
+  isFirefox = window.navigator.userAgent.toLowerCase().includes("firefox");
+}
 
 export interface AutoThemeProviderProps extends ThemeableElement<"div"> {
   /** Whether to automatically change the font and background color */

--- a/packages/themes/src/index.tsx
+++ b/packages/themes/src/index.tsx
@@ -1,2 +1,3 @@
 export * from "./themes";
 export * from "./utils";
+export * from "./AutoThemeProvider";

--- a/packages/themes/src/utils.tsx
+++ b/packages/themes/src/utils.tsx
@@ -1,8 +1,6 @@
 import React from "react";
 import makeClass from "clsx";
-import { isFirefox } from "react-device-detect";
 import { Element } from "@design-systems/utils";
-import { all } from "./themes";
 
 export const colorSchemes = ["light", "dark"] as const;
 export type ColorScheme = typeof colorSchemes[number];
@@ -75,44 +73,6 @@ export const ThemeProvider = ({
   return (
     <ThemeContext.Provider value={{ ...wrappedTheme, ...value }}>
       {children}
-    </ThemeContext.Provider>
-  );
-};
-
-export interface AutoThemeProviderProps extends ThemeableElement<"div"> {
-  /** Whether to automatically change the font and background color */
-  autoStyle?: boolean;
-  /** Any React node children */
-  children: React.ReactNode;
-}
-
-/**
- * A theme provider that automatically detects a users browser and colorScheme.
- * Themes are set for each component using React Context.
- * It also sets the background color and text color to the correct color.
- */
-export const AutoThemeProvider = ({
-  theme: propsTheme,
-  colorScheme: propsColorScheme,
-  autoStyle,
-  children,
-  ...html
-}: AutoThemeProviderProps) => {
-  const isDark = useDarkMode();
-  const colorScheme = propsColorScheme || (isDark ? "dark" : "light");
-  const theme = propsTheme || (isFirefox ? "firefox" : "chrome");
-  const style = {
-    backgroundColor: all[theme][colorScheme].backgroundColor,
-    color: all[theme][colorScheme].textColor,
-    minHeight: "100%",
-    width: "100%",
-  };
-
-  return (
-    <ThemeContext.Provider value={{ theme, colorScheme }}>
-      <div style={autoStyle ? style : undefined} {...html}>
-        {children}
-      </div>
     </ThemeContext.Provider>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1706,7 +1706,7 @@
     react-merge-refs "^1.0.0"
 
 "@devtools-ds/icon@link:components/Icon":
-  version "1.0.1"
+  version "1.0.2"
   dependencies:
     "@babel/runtime" "7.7.2"
     "@design-systems/utils" "2.12.0"
@@ -1714,14 +1714,14 @@
     clsx "1.1.0"
 
 "@devtools-ds/node@link:components/Node":
-  version "1.0.1"
+  version "1.0.2"
   dependencies:
     "@babel/runtime" "7.7.2"
     "@devtools-ds/themes" "link:packages/themes"
     clsx "1.1.0"
 
 "@devtools-ds/object-inspector@link:components/ObjectInspector":
-  version "1.0.1"
+  version "1.0.2"
   dependencies:
     "@babel/runtime" "7.7.2"
     "@devtools-ds/object-parser" "link:packages/object-parser"
@@ -1730,25 +1730,24 @@
     clsx "1.1.0"
 
 "@devtools-ds/object-parser@link:packages/object-parser":
-  version "1.0.1"
+  version "1.0.2"
   dependencies:
     "@babel/runtime" "~7.5.4"
 
 "@devtools-ds/storybook-utils@link:packages/storybook-utils":
-  version "1.0.1"
+  version "1.0.2"
   dependencies:
     "@babel/runtime" "~7.5.4"
 
 "@devtools-ds/themes@link:packages/themes":
-  version "1.0.1"
+  version "1.0.2"
   dependencies:
     "@babel/runtime" "~7.5.4"
     "@design-systems/utils" "2.12.0"
     clsx "1.1.0"
-    react-device-detect "1.15.0"
 
 "@devtools-ds/tree@link:components/Tree":
-  version "1.0.1"
+  version "1.0.2"
   dependencies:
     "@babel/runtime" "7.7.2"
     "@devtools-ds/themes" "link:packages/themes"
@@ -17362,13 +17361,6 @@ react-dev-utils@^10.0.0:
     strip-ansi "6.0.0"
     text-table "0.2.0"
 
-react-device-detect@1.15.0:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/react-device-detect/-/react-device-detect-1.15.0.tgz#5321f94ae3c4d51ef399b0502a6c739e32d0f315"
-  integrity sha512-ywjtWW04U7vaJK87IAFHhKozZhTPeDVWsfYx5CxQSQCjU5+fnMMxWZt9HnVWaNTqBEn6g8wCNWyqav7sXJrURg==
-  dependencies:
-    ua-parser-js "^0.7.23"
-
 react-docgen-typescript-plugin@^0.6.2:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/react-docgen-typescript-plugin/-/react-docgen-typescript-plugin-0.6.3.tgz#664b22601df083597ecb1e60bd21beca60125fdf"
@@ -20606,7 +20598,7 @@ typical@^5.0.0, typical@^5.2.0:
   resolved "https://registry.yarnpkg.com/typical/-/typical-5.2.0.tgz#4daaac4f2b5315460804f0acf6cb69c52bb93066"
   integrity sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==
 
-ua-parser-js@^0.7.18, ua-parser-js@^0.7.21, ua-parser-js@^0.7.23:
+ua-parser-js@^0.7.18, ua-parser-js@^0.7.21:
   version "0.7.23"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.23.tgz#704d67f951e13195fbcd3d78818577f5bc1d547b"
   integrity sha512-m4hvMLxgGHXG3O3fQVAyyAQpZzDOvwnhOTjYz5Xmr7r/+LpkNy3vJXdVRWgd1TkAb7NGROZuSy96CrlNVjA7KA==


### PR DESCRIPTION
# What Changed

I noticed the size of some of the components was pretty large, and did some digging to find out why. It turns out our package template is missing the sideEffects tag, so dependencies were never being tree-shaken.

This meant that:

- `@design-systems/theme` was never tree shaking based on usage.
- AutoThemeProvider was pulling in all of ua-parser-js and all themes.

Breaking that apart and adding `sideEffects` dropped the size of the components, but there are still a couple issues remaining.

![image](https://user-images.githubusercontent.com/5761061/109117097-672d8180-76f6-11eb-8c33-e50dee0eb31e.png)

Webpack is pulling in a `buffer` polyfill that is huge, probably because the Object value and parser reference the type `Buffer`.  I _think_ this might just be something to change in the `size` command webpack config but I need to check.

- [Relevant webpack docs](https://v4.webpack.js.org/configuration/node/#root)
- [DS-CLI Size config](https://github.com/intuit/design-systems-cli/blob/master/plugins/size/src/utils/WebpackUtils.ts#L22)

The last optimization would be to just directly pull in [the regex we need](https://github.com/faisalman/ua-parser-js/blob/master/src/ua-parser.js#L392) to detect firefox, so we don't need a full UA parser.

