### PR TITLE
Increase maximum parse depth for larger JSON objects

### DIFF
--- a/packages/object-parser/src/index.ts
+++ b/packages/object-parser/src/index.ts
@@ -266,7 +266,7 @@ const buildAST = async (
     parent: undefined,
   };
 
-  if (value && isKnownObject(value) && depth < 10) {
+  if (value && isKnownObject(value) && depth < 100) {
     const children = [];
     let t: ObjectTypes = "object";
 


### PR DESCRIPTION
# What Changed

The 10 maximum depth was being hit on larger JSON payloads. Since the introduction of the lazy expansion of children, I'm not entirely sure if we still need this limit (or potentially another way to spot circular references), but this increases it to a larger 100 max-depth 
