### PR TITLE
feat(table): sticky header

### DIFF
--- a/components/Table/src/Table.css
+++ b/components/Table/src/Table.css
@@ -13,6 +13,10 @@
 .table-head {
   background-color: @theme headBackgroundColor;
   text-align: left;
+  position: sticky;
+  top: 0;
+  box-shadow: 0px 1px 0 0px @theme borderColor,
+    0px -1px 0 0px @theme borderColor;
 }
 
 .cell-head {

--- a/components/Table/src/stories/Features.stories.tsx
+++ b/components/Table/src/stories/Features.stories.tsx
@@ -215,3 +215,53 @@ export const Overflow = () => {
     </Table>
   );
 };
+
+export const HeightOverflow = () => {
+  const ROWS = [
+    "two",
+    "three",
+    "four",
+    "five",
+    "six",
+    "seven",
+    "eight",
+    "night",
+    "ten",
+    "eleven",
+    "twelve",
+  ];
+
+  return (
+    <div style={{ maxHeight: "200px", overflow: "scroll" }}>
+      <Table>
+        <Table.Head>
+          <Table.Row>
+            <Table.HeadCell style={{ width: "10%" }}>Status</Table.HeadCell>
+            <Table.HeadCell style={{ width: "10%" }}>Method</Table.HeadCell>
+            <Table.HeadCell>Domain</Table.HeadCell>
+            <Table.HeadCell>Transferred</Table.HeadCell>
+          </Table.Row>
+        </Table.Head>
+        <Table.Body>
+          <Table.Row id="one">
+            <Table.Cell>200</Table.Cell>
+            <Table.Cell>GET</Table.Cell>
+            <Table.Cell>
+              This is some really long text that has spaces so it should break
+              in theory.
+            </Table.Cell>
+            <Table.Cell>This_is_a_longer_value_which_wont_break_</Table.Cell>
+          </Table.Row>
+          {ROWS.map((row) => (
+            <Table.Row id={row}>
+              <Table.Cell>301</Table.Cell>
+              <Table.Cell>GET</Table.Cell>
+              <Table.Cell>localhost:6006</Table.Cell>
+              <Table.Cell>0.2 KB</Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table>
+    </div>
+  );
+};

--- a/components/Table/src/stories/Overview.stories.mdx
+++ b/components/Table/src/stories/Overview.stories.mdx
@@ -52,3 +52,11 @@ Each column is user-resizable, and the `Table` will automatically fill the space
 <Canvas>
   <Story id="components-table-features--in-container" />
 </Canvas>
+
+### Overflow
+
+Table head automatically will stick to the top
+
+<Canvas>
+  <Story id="components-table-features--height-overflow" />
+</Canvas>


### PR DESCRIPTION
# What Changed

Now the table has a sticky header. It will behave as you expect, sticking to the top when needed.

# Why

The content of the table could be longer than expected, as a sequence of logs.

![Screen Shot 2022-04-07 at 9 09 07 PM](https://user-images.githubusercontent.com/1523379/162360842-8fffc145-513f-4a0a-818a-06b900d06ac9.png)


# What might be impacted

Styles could be broken for some browsers.

Firefox & Chrome [support sticky](https://caniuse.com/css-sticky) headers.

Todo:

- [X] Add tests
- [X] Add docs
